### PR TITLE
fix(security): pin GitHub Actions to commit SHAs in publish workflow

### DIFF
--- a/.github/workflows/pytest_and_autopublish.yml
+++ b/.github/workflows/pytest_and_autopublish.yml
@@ -17,10 +17,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     # Install deps
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip --version
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     # Publish the package (if local `__version__` > pip version)
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This publish workflow uses a mutable tag reference for **`etils-actions/pypi-auto-publish@v1`** — a third-party action. If the tag is silently redirected (compromised maintainer, repo takeover, tag deletion + recreation), malicious code executes in the job that holds `PYPI_API_TOKEN`, enabling a supply-chain attack on every downstream user.

## Fix

All actions pinned to immutable commit SHAs (tag preserved as comment for readability). This follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).